### PR TITLE
switchport sanity

### DIFF
--- a/admin/all_ports_uc.json
+++ b/admin/all_ports_uc.json
@@ -1,0 +1,975 @@
+# Created with otput from idrac_switchview playbook
+# to generate, execute `jq -n 'reduce inputs as $s (.; .[input_filename] += $s)' *.json > all_ports2.json`
+# (or preferrably something better...)
+
+{
+  "nc01.json": [
+    {
+      "mac_address": "24:6E:96:79:3B:78",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/1:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:3B:7A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/33:1"
+    }
+  ],
+  "nc02.json": [
+    {
+      "mac_address": "24:6E:96:79:1A:44",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/2:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1A:46",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/34:1"
+    }
+  ],
+  "nc03.json": [
+    {
+      "mac_address": "24:6E:96:79:1B:98",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/3:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1B:9A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/35:1"
+    }
+  ],
+  "nc04.json": [
+    {
+      "mac_address": "24:6E:96:79:3A:68",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/4:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:3A:6A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/56:4"
+    }
+  ],
+  "nc05.json": [
+    {
+      "mac_address": "24:6E:96:7E:03:10",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/56:3"
+    },
+    {
+      "mac_address": "24:6E:96:7E:03:0E",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/5:1"
+    }
+  ],
+  "nc06.json": [
+    {
+      "mac_address": "24:6E:96:7E:0F:AC",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/6:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:0F:AE",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/56:2"
+    }
+  ],
+  "nc07.json": [
+    {
+      "mac_address": "24:6E:96:7D:F5:E8",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/7:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:F5:EA",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/56:1"
+    }
+  ],
+  "nc08.json": [
+    {
+      "mac_address": "24:6E:96:7E:10:BE",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/55:4"
+    },
+    {
+      "mac_address": "24:6E:96:7E:10:BC",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/8:1"
+    }
+  ],
+  "nc09.json": [
+    {
+      "mac_address": "24:6E:96:79:1D:96",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/9:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1D:98",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/55:3"
+    }
+  ],
+  "nc10.json": [
+    {
+      "mac_address": "24:6E:96:7D:FC:D0",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/10:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FC:D2",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/55:2"
+    }
+  ],
+  "nc11.json": [
+    {
+      "mac_address": "24:6E:96:7E:11:22",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/11:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:11:24",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/55:1"
+    }
+  ],
+  "nc12.json": [
+    {
+      "mac_address": "24:6E:96:7D:FA:06",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/12:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FA:08",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/54:4"
+    }
+  ],
+  "nc13.json": [
+    {
+      "mac_address": "24:6E:96:79:1C:00",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/54:3"
+    },
+    {
+      "mac_address": "24:6E:96:79:1B:FE",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/13:1"
+    }
+  ],
+  "nc14.json": [
+    {
+      "mac_address": "24:6E:96:7E:0F:F2",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/54:2"
+    },
+    {
+      "mac_address": "24:6E:96:7E:0F:F0",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/14:1"
+    }
+  ],
+  "nc15.json": [
+    {
+      "mac_address": "24:6E:96:79:1F:0C",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/15:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1F:0E",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/54:1"
+    }
+  ],
+  "nc16.json": [
+    {
+      "mac_address": "24:6E:96:7D:AB:18",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/16:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:AB:1A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/53:4"
+    }
+  ],
+  "nc17.json": [
+    {
+      "mac_address": "24:6E:96:7D:FA:4A",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/17:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FA:4C",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/53:3"
+    }
+  ],
+  "nc18.json": [
+    {
+      "mac_address": "24:6E:96:7D:F9:7E",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/18:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:F9:80",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/53:2"
+    }
+  ],
+  "nc19.json": [
+    {
+      "mac_address": "24:6E:96:7D:FA:28",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/19:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FA:2A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/53:1"
+    }
+  ],
+  "nc20.json": [
+    {
+      "mac_address": "24:6E:96:7E:2B:2A",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/25:1"
+    }
+  ],
+  "nc21.json": [
+    {
+      "mac_address": "24:6E:96:7E:12:BC",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/37:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:12:BA",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/21:1"
+    }
+  ],
+  "nc24.json": [
+    {
+      "mac_address": "24:6E:96:7E:24:42",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/24:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:24:44",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/40:1"
+    }
+  ],
+  "nc25.json": [
+    {
+      "mac_address": "24:6E:96:7E:0F:68",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/25:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:0F:6A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/41:1"
+    }
+  ],
+  "nc26.json": [
+    {
+      "mac_address": "24:6E:96:7E:30:9C",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/26:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:30:9E",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/42:1"
+    }
+  ],
+  "nc27.json": [
+    {
+      "mac_address": "24:6E:96:7D:AA:F6",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/27:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:AA:F8",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/43:1"
+    }
+  ],
+  "nc28.json": [
+    {
+      "mac_address": "24:6E:96:7D:A5:20",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/44:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:A5:1E",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/28:1"
+    }
+  ],
+  "nc29.json": [
+    {
+      "mac_address": "24:6E:96:7D:96:82",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/29:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:96:84",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/45:1"
+    }
+  ],
+  "nc30.json": [
+    {
+      "mac_address": "24:6E:96:7D:AE:26",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/30:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:AE:28",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/46:1"
+    }
+  ],
+  "nc31.json": [
+    {
+      "mac_address": "24:6E:96:7E:0B:28",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/31:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:0B:2A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/47:1"
+    }
+  ],
+  "nc32.json": [
+    {
+      "mac_address": "24:6E:96:7D:7E:34",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/32:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:7E:36",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:44:41",
+      "switch_info": "sw-tor-bf41",
+      "switch_port_id": "ethernet1/1/48:1"
+    }
+  ],
+  "nc33.json": [
+    {
+      "mac_address": "24:6E:96:7E:1F:C0",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/46:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:1F:BE",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/30:1"
+    }
+  ],
+  "nc34.json": [
+    {
+      "mac_address": "24:6E:96:7D:77:F6",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/31:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:77:F8",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/47:1"
+    }
+  ],
+  "nc35.json": [
+    {
+      "mac_address": "24:6E:96:7E:24:86",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/32:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:24:88",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/48:1"
+    }
+  ],
+  "nc36.json": [
+    {
+      "mac_address": "24:6E:96:7D:FD:7C",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/33:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FD:7A",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/1:1"
+    }
+  ],
+  "nc37.json": [
+    {
+      "mac_address": "24:6E:96:7D:FF:DE",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/2:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FF:E0",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/34:1"
+    }
+  ],
+  "nc38.json": [
+    {
+      "mac_address": "24:6E:96:7D:9F:48",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/35:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:9F:46",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/3:1"
+    }
+  ],
+  "nc39.json": [
+    {
+      "mac_address": "24:6E:96:7D:FD:BE",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/4:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FD:C0",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/56:4"
+    }
+  ],
+  "nc40.json": [
+    {
+      "mac_address": "24:6E:96:7D:AF:E0",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/5:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:AF:E2",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/56:3"
+    }
+  ],
+  "nc41.json": [
+    {
+      "mac_address": "24:6E:96:7D:84:2E",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/6:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:84:30",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/56:2"
+    }
+  ],
+  "nc42.json": [
+    {
+      "mac_address": "24:6E:96:7D:FF:BC",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/7:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FF:BE",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/56:1"
+    }
+  ],
+  "nc43.json": [
+    {
+      "mac_address": "24:6E:96:7D:FD:E0",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/8:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FD:E2",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/55:4"
+    }
+  ],
+  "nc44.json": [
+    {
+      "mac_address": "24:6E:96:7E:00:CE",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/55:3"
+    },
+    {
+      "mac_address": "24:6E:96:7E:00:CC",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/9:1"
+    }
+  ],
+  "nc45.json": [
+    {
+      "mac_address": "24:6E:96:7D:FF:12",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/10:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FF:14",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/55:2"
+    }
+  ],
+  "nc46.json": [
+    {
+      "mac_address": "24:6E:96:7D:AD:C0",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/11:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:AD:C2",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/55:1"
+    }
+  ],
+  "nc47.json": [
+    {
+      "mac_address": "24:6E:96:7D:7B:48",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/12:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:7B:4A",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/54:4"
+    }
+  ],
+  "nc48.json": [
+    {
+      "mac_address": "24:6E:96:7D:AC:B0",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/13:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:AC:B2",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/54:3"
+    }
+  ],
+  "nc49.json": [
+    {
+      "mac_address": "24:6E:96:7D:FA:6C",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/14:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FA:6E",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/54:2"
+    }
+  ],
+  "nc50.json": [
+    {
+      "mac_address": "24:6E:96:7D:7C:7A",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/15:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:7C:7C",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/54:1"
+    }
+  ],
+  "nc51.json": [
+    {
+      "mac_address": "24:6E:96:7D:A5:62",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/16:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:A5:64",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/53:4"
+    }
+  ],
+  "nc52.json": [
+    {
+      "mac_address": "24:6E:96:7D:7D:02",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/17:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:7D:04",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/53:3"
+    }
+  ],
+  "nc53.json": [
+    {
+      "mac_address": "24:6E:96:7E:29:4E",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/18:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:29:50",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/53:2"
+    }
+  ],
+  "nc54.json": [
+    {
+      "mac_address": "24:6E:96:7D:A5:A8",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/53:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:A5:A6",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/19:1"
+    }
+  ],
+  "nc55.json": [
+    {
+      "mac_address": "24:6E:96:7E:25:98",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/36:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:25:96",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/20:1"
+    }
+  ],
+  "nc57.json": [
+    {
+      "mac_address": "24:6E:96:7E:28:EA",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/38:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:28:E8",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/22:1"
+    }
+  ],
+  "nc58.json": [
+    {
+      "mac_address": "24:6E:96:79:1A:22",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/23:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1A:24",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/39:1"
+    }
+  ],
+  "nc59.json": [
+    {
+      "mac_address": "24:6E:96:79:1B:DC",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/24:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1B:DE",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/40:1"
+    }
+  ],
+  "nc60.json": [
+    {
+      "mac_address": "24:6E:96:7D:87:3C",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/25:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:87:3E",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/41:1"
+    }
+  ],
+  "nc61.json": [
+    {
+      "mac_address": "24:6E:96:7E:2E:E2",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/26:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:2E:E4",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/42:1"
+    }
+  ],
+  "nc62.json": [
+    {
+      "mac_address": "24:6E:96:79:1B:56",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/43:1"
+    },
+    {
+      "mac_address": "24:6E:96:79:1B:54",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/27:1"
+    }
+  ],
+  "nc63.json": [
+    {
+      "mac_address": "24:6E:96:7E:30:14",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/28:1"
+    },
+    {
+      "mac_address": "24:6E:96:7E:30:16",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/44:1"
+    }
+  ],
+  "nc64.json": [
+    {
+      "mac_address": "24:6E:96:7D:FC:6C",
+      "name": "NIC.Integrated.1-2-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/45:1"
+    },
+    {
+      "mac_address": "24:6E:96:7D:FC:6A",
+      "name": "NIC.Integrated.1-1-1",
+      "switch_id": "8c:47:be:c5:28:41",
+      "switch_info": "sw-tor-bd41",
+      "switch_port_id": "ethernet1/1/29:1"
+    }
+  ]
+}

--- a/admin/playbooks/configure_idrac_discovery.yml
+++ b/admin/playbooks/configure_idrac_discovery.yml
@@ -1,0 +1,21 @@
+# example for enabling idrac topology lldp and other settings
+
+---
+- name: Dell OpenManage Ansible iDRAC
+  hosts: idrac
+  gather_facts: false
+
+  tasks:
+    - name: Configure LLDP Toplogy Discovery
+      dellemc.openmanage.idrac_attributes:
+        idrac_ip: "{{ idrac_ip }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        validate_certs: False
+        idrac_attributes:
+           NIC.1.DNSRacName: "iDRAC-{{inventory_hostname}}"
+           NIC.1.TopologyLldp: Enabled
+          #  Serial.1.Enable: Disabled
+           IPMISOL.1.BaudRate: 115200
+           IPMISOL.1.Enable: Enabled
+      delegate_to: localhost

--- a/admin/playbooks/get_switch_host_macs.yml
+++ b/admin/playbooks/get_switch_host_macs.yml
@@ -1,0 +1,125 @@
+# demonstrate method to get mac-address table via XML from switch CLI.
+# This is the wrong way to do things, we should get this table from SNMP, restconf, or other mechanism so that there's an API.
+# <sad escape character noises>
+---
+- name: Get Mac Addresses from Switches
+  hosts: os10_switches
+  gather_facts: false
+  connection: network_cli
+  collections:
+    - dellemc.os10
+  tasks:
+    - name: get_mac_table
+      os10_command:
+        commands: show mac address-table | display-xml
+      register: mac_table_xml_result
+    - name: un_escape_xml
+      set_fact:
+        plain_xml: "{{ mac_table_xml_result.stdout[0] | regex_replace('[\\r\\n\\t]+','') | regex_replace('[\\\"]+','\"') }}"
+    # - debug:
+    #     var: plain_xml | ansible.utils.from_xml
+    - set_fact:
+        parsed_xml: "{{ plain_xml | ansible.utils.from_xml }}"
+    - set_fact:
+        mac_table_list: "{{parsed_xml['rpc-reply']['bulk']['data']['fwd-table']}}"
+        mac_iface_mapping: {}
+        mac_switch_name_mapping: {}
+    - set_fact:
+        mac_iface_mapping: "{{ mac_iface_mapping | combine( { mac_address: interface } ) }}"
+        mac_switch_name_mapping: "{{ mac_switch_name_mapping | combine( { mac_address: inventory_hostname } ) }}"
+      vars:
+        mac_address: "{{item['mac-addr']}}"
+        interface: "{{item['if-name']}}"
+      loop: "{{mac_table_list}}"
+      when: item['if-name'] != "ethernet1/1/52"
+    - name: print_iface_maps
+      debug:
+        var: mac_iface_mapping
+    - name: print_swname_maps
+      debug:
+        var: mac_switch_name_mapping
+
+- name: Dell OpenManage Ansible iDRAC
+  hosts: idrac
+  gather_facts: false
+
+  tasks:
+#  - name: iDRAC gather facts for System, BIOS, Controller, CPU, Enclosure.
+#    delegate_to: localhost
+#    import_role:
+#      name: dellemc.openmanage.idrac_gather_facts
+#    vars:
+#      hostname: "{{ idrac_ip }}"
+#      username: "{{ idrac_user }}"
+#      password: "{{ idrac_password }}"
+#      validate_certs: False
+#      target:
+#        - NIC
+  - name: iDRAC gather facts
+    delegate_to: localhost
+    dellemc.openmanage.idrac_system_info:
+      idrac_ip: "{{ idrac_ip }}"
+      idrac_user: "{{ idrac_user }}"
+      idrac_password: "{{ idrac_password }}"
+      validate_certs: False
+    register: idrac_facts_result
+
+  - debug:
+      msg: "{{idrac_facts_result['system_info']['NIC']}}"
+
+  - name: set_facts_switch_macs
+    set_fact:
+      mac_iface_mapping: "{{ bd41_ifaces | combine(bf41_ifaces)}}"
+      mac_switch_name_mapping: "{{ bd41_names | combine(bf41_names)}}"
+    vars:
+      bd41_ifaces: "{{ hostvars['sw-tor-bd41']['mac_iface_mapping'] }}"
+      bf41_ifaces: "{{ hostvars['sw-tor-bf41']['mac_iface_mapping'] }}"
+      bd41_names: "{{ hostvars['sw-tor-bd41']['mac_switch_name_mapping'] }}"
+      bf41_names: "{{ hostvars['sw-tor-bf41']['mac_switch_name_mapping'] }}"
+
+  - name: node_interfaces_fact
+    set_fact:
+      interfaces: []
+
+  - name: set_node_ifaces_fact
+    set_fact:
+      interfaces: "{{ interfaces + [ local_link_connection ] }}"
+    vars:
+      mac_address_outer: "{{item.MACAddress | lower }}"
+      linkstatus: "{{item.LinkStatus}}"
+      switch_info_outer: "{{ mac_switch_name_mapping[mac_address_outer] | default(None) }}"
+      local_link_connection:
+        mac_address: "{{ mac_address_outer }}"
+        name: "{{item.Id}}"
+        switch_info: "{{ switch_info_outer }}"
+        switch_id: "{{hostvars[switch_info_outer]['switch_id'] | default(None) }}"
+        switch_port_id: "{{ mac_iface_mapping[mac_address_outer] | default(None) }}"
+    #loop: "{{nic}}"
+    loop: "{{idrac_facts_result['system_info']['NIC']}}"
+    when: linkstatus=="LinkUp"
+    when: LinkStatus=="Up"
+
+  - name: template_doni_json
+    delegate_to: localhost
+    ansible.builtin.template:
+      src: doni_node.j2
+      dest: "/tmp/output/{{inventory_hostname}}-doni.json"
+    vars:
+      interfaces: "{{interfaces}}"
+
+
+
+  # - name: Print the System details
+  #   delegate_to: localhost
+  #   ansible.builtin.template:
+  #     src: node_ports.j2
+  #     dest: "/tmp/output/{{inventory_hostname}}-{{portname}}.json"
+  #   vars:
+  #     mac_address: "{{item.MACAddress | lower }}"
+  #     portname: "{{item.Id}}"
+  #     switch_info: "{{ mac_switch_name_mapping[mac_address] }}"
+  #     switch_id: "{{hostvars[switch_info]['switch_id']}}"
+  #     switch_port_id: "{{ mac_iface_mapping[mac_address] }}"
+  #     linkstatus: "{{item.LinkStatus}}"
+  #   loop: "{{nic}}"
+  #   when: linkstatus=="LinkUp"

--- a/admin/playbooks/hosts.ini
+++ b/admin/playbooks/hosts.ini
@@ -1,0 +1,82 @@
+# Example file from UC with secrets redacted
+[os10_switches]
+sw-tor-bd41 switch_id="8c:47:be:c5:28:41"
+sw-tor-bf41 switch_id="8c:47:be:c5:44:41"
+
+[os10_switches:vars]
+ansible_ssh_user=<redacted!>
+ansible_ssh_pass=<redacted!>
+ansible_network_os=dellemc.os10.os10
+
+[idrac]
+; nc01 idrac_ip=172.30.0.10
+; nc02 idrac_ip=172.30.0.11
+; nc03 idrac_ip=172.30.0.12
+; nc04 idrac_ip=172.30.0.13
+; nc05 idrac_ip=172.30.0.14
+; nc06 idrac_ip=172.30.0.15
+; nc07 idrac_ip=172.30.0.16
+; nc08 idrac_ip=172.30.0.17
+; nc09 idrac_ip=172.30.0.18
+; nc10 idrac_ip=172.30.0.19
+; nc11 idrac_ip=172.30.0.20
+; nc12 idrac_ip=172.30.0.21
+; nc13 idrac_ip=172.30.0.22
+; nc14 idrac_ip=172.30.0.23 # node idrac timing out
+; nc15 idrac_ip=172.30.0.24
+; nc16 idrac_ip=172.30.0.25
+; nc17 idrac_ip=172.30.0.26
+; nc18 idrac_ip=172.30.0.27
+; nc19 idrac_ip=172.30.0.28
+nc20 idrac_ip=172.30.0.29
+; nc21 idrac_ip=172.30.0.30
+nc22 idrac_ip=172.30.0.31 # node idrac is dead
+nc23 idrac_ip=172.30.0.32 # node idrac is dead
+; nc24 idrac_ip=172.30.0.33
+; nc25 idrac_ip=172.30.0.34
+; nc26 idrac_ip=172.30.0.35
+; nc27 idrac_ip=172.30.0.36
+; nc28 idrac_ip=172.30.0.37
+; nc29 idrac_ip=172.30.0.38 # will not power on!
+; nc30 idrac_ip=172.30.0.39
+; nc31 idrac_ip=172.30.0.40
+; nc32 idrac_ip=172.30.0.41
+nc33 idrac_ip=172.30.0.42
+; nc34 idrac_ip=172.30.0.43
+nc35 idrac_ip=172.30.0.44
+; nc36 idrac_ip=172.30.0.45
+; nc37 idrac_ip=172.30.0.46
+; nc38 idrac_ip=172.30.0.47
+; nc39 idrac_ip=172.30.0.48
+; nc40 idrac_ip=172.30.0.49
+; nc41 idrac_ip=172.30.0.50
+; nc42 idrac_ip=172.30.0.51
+; nc43 idrac_ip=172.30.0.52
+; nc44 idrac_ip=172.30.0.53
+; nc45 idrac_ip=172.30.0.54
+; nc46 idrac_ip=172.30.0.55
+; nc47 idrac_ip=172.30.0.56
+; nc48 idrac_ip=172.30.0.57
+; nc49 idrac_ip=172.30.0.58
+; nc50 idrac_ip=172.30.0.59
+; nc51 idrac_ip=172.30.0.60
+; nc52 idrac_ip=172.30.0.61
+; nc53 idrac_ip=172.30.0.62
+; nc54 idrac_ip=172.30.0.63
+; nc55 idrac_ip=172.30.0.64
+nc56 idrac_ip=172.30.0.65 # node idrac is dead
+; nc57 idrac_ip=172.30.0.66
+; nc58 idrac_ip=172.30.0.67
+; nc59 idrac_ip=172.30.0.68
+; nc60 idrac_ip=172.30.0.69
+; nc61 idrac_ip=172.30.0.70
+; nc62 idrac_ip=172.30.0.71
+; nc63 idrac_ip=172.30.0.72
+; nc64 idrac_ip=172.30.0.73
+
+
+[idrac:vars]
+idrac_user=<redacted!>
+idrac_password=<redacted!>
+
+switch_name_map={"8c:47:be:c5:28:41": "sw-tor-bd41","8c:47:be:c5:44:41": "sw-tor-bf41"}

--- a/admin/playbooks/idrac_switchinfo.yml
+++ b/admin/playbooks/idrac_switchinfo.yml
@@ -1,0 +1,41 @@
+---
+- name: Dell OpenManage Ansible iDRAC
+  hosts: idrac
+  gather_facts: false
+  tasks:
+  - name: iDRAC gather facts
+    delegate_to: localhost
+    dellemc.openmanage.idrac_system_info:
+      idrac_ip: "{{ idrac_ip }}"
+      idrac_user: "{{ idrac_user }}"
+      idrac_password: "{{ idrac_password }}"
+      validate_certs: False
+    register: idrac_facts_result
+
+  - name: node_interfaces_fact
+    set_fact:
+      interfaces: []
+      nics: "{{idrac_facts_result['system_info']['NIC']}}"
+
+
+  - name: set_node_ifaces_fact
+    set_fact:
+      interfaces: "{{ interfaces + [ local_link_connection ] }}"
+    vars:
+      switch_id_outer: "{{ item.SwitchConnectionID }}"
+      local_link_connection:
+        mac_address: "{{ item.PermanentMACAddress }}"
+        name: "{{ item.FQDD }}"
+        switch_id: "{{ switch_id_outer }}"
+        switch_info: "{{ switch_name_map[switch_id_outer] }}"
+        switch_port_id: "{{ item.SwitchPortConnectionID }}"
+    loop: "{{nics}}"
+    when:
+      - item.Protocol == 'NIC'
+      - item.LinkStatus == "Up"
+
+  - name: template_doni_json
+    delegate_to: localhost
+    ansible.builtin.copy:
+      content: "{{interfaces | to_nice_json }}"
+      dest: "/tmp/output/{{inventory_hostname}}.json"

--- a/cc_toolkit/admin/update_ironic_ports.py
+++ b/cc_toolkit/admin/update_ironic_ports.py
@@ -1,0 +1,76 @@
+#!python3
+
+import openstack
+import json
+from openstack.exceptions import ConflictException
+
+def main():
+
+    with open("all_ports2.json") as fp:
+        portinfodict = json.load(fp)
+
+    node_port_dict = {}
+
+    for key, val in portinfodict.items():
+        nodename = str.split(key,".")[0]
+
+        port_dict = {}
+        for port in val:
+            mac_address = str.lower(port.get("mac_address"))
+            port_dict[mac_address] = {
+                "name": port.get("name"),
+                "switch_id": str.lower(port.get("switch_id")),
+                "switch_info": str.lower(port.get("switch_info")),
+                "switch_port_id" : str.replace(port.get("switch_port_id"), "ethernet",""),
+            }
+        node_port_dict[nodename]=port_dict
+
+
+    conn = openstack.connect(cloud='uc_admin')
+
+    for node_name, ports in node_port_dict.items():
+        current_node = conn.baremetal.get_node(node_name)
+
+        for mac_address, values in ports.items():
+
+            new_llc = {
+                "switch_id": values["switch_id"],
+                "port_id": values["switch_port_id"],
+                "switch_info": values["switch_info"],
+            }
+
+            new_extra = {"name":  values["name"]}
+
+
+            current_ports = list(conn.baremetal.ports(details=True,  address=mac_address))
+            if len(current_ports) > 1:
+                raise Exception("Duplicate MAC Addr!")
+            elif len(current_ports) == 1:
+                # if the port exists already, just update it
+                current_port = current_ports[0]
+                current_llc = current_port.get("local_link_connection")
+                current_extra = current_port.get("extra")
+                is_maintenance = current_node.is_maintenance
+                if current_llc!=new_llc or current_extra!=new_extra:
+                    print(f"updating info for node {current_node.name} port {current_port.id}")
+                    print(current_llc, new_llc,current_extra,new_extra)
+                    try:
+                        conn.baremetal.update_port(current_port.id, local_link_connection=new_llc, extra=new_extra)
+                    except ConflictException as ex:
+                        conn.baremetal.set_node_maintenance(current_node.id)
+                        conn.baremetal.update_port(current_port.id, local_link_connection=new_llc)
+                    finally:
+                        if not is_maintenance:
+                            conn.baremetal.unset_node_maintenance(current_node.id)
+            else:
+                # need to make a new port
+                new_port = conn.baremetal.create_port(
+                    address = mac_address,
+                    local_link_connection=new_llc,
+                    extras = new_extra,
+                    node_uuid = current_node.id
+                )
+                print(new_port)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
note to reviewers: I thought you'd be interested, but it's not at ALL in a state for merging, and possibly not even for this repo.

features of note:

* getting arp table from dell switches in XML format
* dell os10 and idrac ansible collections exist, idrac one is mostly a wrapper around redfish APIs
* it is in-fact possible to match up the ARP table entries on a given switch with the interfaces from IDRAC, and guess the "Correct" ones to enable based on if they have link up.
* If we assign the "switch_id" mac address in local_link_connection to the same one that switches advertise via LLDP, the process can be significantly automated
* the idrac "topology LLDP" feature causes servers to emit lldp packets via in-band interfaces, telling switches what they are. Buut, we need to find out what mac address idrac sends, because it doesn't match the switchport mac, and it's different for each switchport.

Finally: N methods were used because we have multiple different versions of idrac, all of which support slightly different features. We should upgrade them all and just use redfish.
